### PR TITLE
Add var tag to config reader

### DIFF
--- a/duct/src/duct/util/system.clj
+++ b/duct/src/duct/util/system.clj
@@ -13,6 +13,9 @@
 (defmethod reader 'resource [_ value]
   (io/resource value))
 
+(defmethod reader 'var [_ value]
+  (ns/load-var value))
+
 (defn read-config [source bindings]
   (->> (slurp source)
        (edn/read-string {:default reader})


### PR DESCRIPTION
This adds a simple `#var` reader tag that can be used in the configuration map.

The reason for this change is that currently vars are only `(require ..)`'d in the `:component` and `:endpoint` sections of the system map. Adding the `#var` tag allows for the following functionality:

````clojure
{...
 :config
 {:fixtures {:adapter #var fixtures.adapters.jdbc/jdbc-adapter ...}
 ...}
````

I think this deserves to be build into duct, as otherwise users have to use `bindings` during `load-system`, which moves slightly away from a purely declarative data configuration, and requires changes to code, rather than a simple addition to the system map. Having this built into duct may allow for easier 3rd party component integration.

One "issue" with this addition, is that it causes vars to be handled in two different ways in the system map:
1) vars are "naked" (i.e., without tag) in `:components` and `:endpoints`
2) vars are tagged in `:config`

Maybe all vars should be tagged with `#var`?