### PR TITLE
Fix class name in boundary generator

### DIFF
--- a/generate/resources/duct/generate/templates/boundary/source.clj
+++ b/generate/resources/duct/generate/templates/boundary/source.clj
@@ -6,6 +6,6 @@
   )
 
 (extend-protocol {{protocol}}
-  {{component-ns}}.{{component}}
+  {{component}}
   ;; boundary implementation
   )

--- a/generate/src/duct/generate.clj
+++ b/generate/src/duct/generate.clj
@@ -14,9 +14,12 @@
   [prefix]
   (alter-var-root #'*ns-prefix* (constantly (str prefix))))
 
+(defn- name-to-classname [name]
+  (str/replace name "-" "_"))
+
 (defn- name-to-path [name]
   (-> name
-      (str/replace "-" "_")
+      (name-to-classname)
       (str/replace "." java.io.File/separator)))
 
 (defn camel-case [hyphenated]
@@ -92,7 +95,8 @@
   [name component-sym]
   (assert-ns-prefix)
   (let [namespace           (str *ns-prefix* ".boundary." name)
-        [comp-ns comp-name] (split-component component-sym)]
+        [comp-ns comp-class] (split-component component-sym)
+        comp-name (name-to-classname (str comp-ns "." comp-class))]
     (doto {:name         (str name)
            :namespace    namespace
            :path         (name-to-path namespace)


### PR DESCRIPTION
When the namespace of the given component contains a hyphen, the
generated boundary cannot be compiled due to a class not found
exception. The reason is the generated component name does not point
to a Java class, since the corresponding class name contains
underscores instead of hyphens.