### PR TITLE
Block main thread indefinitely after starting system

### DIFF
--- a/lein-template/resources/leiningen/new/duct/base/main.clj
+++ b/lein-template/resources/leiningen/new/duct/base/main.clj
@@ -23,4 +23,5 @@
 (defn -main [& args]
   (doto (read-config)
     (logging/set-config!)
-    (run-system)))
+    (run-system))
+  (.. Thread currentThread join))


### PR DESCRIPTION
We need to block main thread to prevent system from shutting down immediately after starting.

With default jetty server this (accidentally) isn't a problem as it apparently creates some non-daemon threads. However if you switch to a different server component which doesn't create non-daemon threads the app exits immediately.

(I found this issue after switching to Aleph component)