### PR TITLE
Add logs directory to template .gitignore

### DIFF
--- a/lein-template/resources/leiningen/new/duct/base/gitignore
+++ b/lein-template/resources/leiningen/new/duct/base/gitignore
@@ -1,4 +1,5 @@
 /target
+/logs
 /classes
 /checkouts
 pom.xml


### PR DESCRIPTION
The default configuration of `:duct.module/logging` writes to "logs/dev.log" when `:duct.core/environment` is `:development`.