### PR TITLE
Fix path where the `local.clj` file is created

### DIFF
--- a/lein-duct/src/leiningen/duct.clj
+++ b/lein-duct/src/leiningen/duct.clj
@@ -14,7 +14,7 @@
   (copy-resource "leiningen/duct/profiles.clj" "profiles.clj")
   (copy-resource "leiningen/duct/dir-locals.el" ".dir-locals.el")
   (copy-resource "leiningen/duct/local.edn" "dev/resources/local.edn")
-  (copy-resource "leiningen/duct/local.clj" "dev/src/local.clj"))
+  (copy-resource "leiningen/duct/local.clj" "dev/src/clj/local.clj"))
 
 (defn duct
   "Tasks for managing a Duct project."


### PR DESCRIPTION
When called `duct setup` the `local.clj` file is created at a wrong location so that it cannot be loaded in the dev env.

This change updates the part of the code that creates the file so that the file is created at the correct location (`dev/src/clj/local.clj`).