### PR TITLE
Remove 'target/resources' from resource-path

### DIFF
--- a/lein-template/resources/leiningen/new/duct/base/project.clj
+++ b/lein-template/resources/leiningen/new/duct/base/project.clj
@@ -14,7 +14,7 @@
   :plugins [[duct/lein-duct "0.9.1"]]
   :main ^:skip-aot {{namespace}}.main{{#uberjar-name}}
   :uberjar-name  "{{uberjar-name}}"{{/uberjar-name}}
-  :resource-paths ["resources" "target/resources"]
+  :resource-paths ["resources"]
   :prep-tasks     ["javac" "compile" ["run" ":duct/compiler"]]
   :profiles
   {:dev  [:project/dev :profiles/dev]


### PR DESCRIPTION
I believe having `target/resources` in the class path may cause subtle bugs related to reloading.
The reason is that some tools like figwheel (as configured in `duct.module.cljs`) populate this path with `.cljc` files (maybe to support source maps).
By default `clojure.tools.namespace.repl/refresh` reloads all clojure files in the class path including those files produced by figwheel.
This behavior does not seem desirable because there is no reason to reload these files.
Furthermore, it may be a source for bugs if those namespaces were not meant to be reloadable.