### PR TITLE
Add Shrubbery to dev dependencies

### DIFF
--- a/lein-template/resources/leiningen/new/duct/base/project.clj
+++ b/lein-template/resources/leiningen/new/duct/base/project.clj
@@ -27,4 +27,5 @@
                   :resource-paths ["dev/resources"]
                   :dependencies   [[integrant/repl "0.2.0"]
                                    [eftest "0.3.1"]
-                                   [kerodon "0.8.0"]]}})
+                                   [kerodon "0.8.0"]
+                                   [com.gearswithingears/shrubbery "0.4.1"]]}})


### PR DESCRIPTION
There is a sentence in wiki page about [Boundaries](https://github.com/duct-framework/duct/wiki/Boundaries).

> Duct includes Shrubbery as part of your dev dependencies for this purpose.

It seems like there is no Shrubbery included at the moment.