### PR TITLE
Allow external profiles to modify config.edn file

### DIFF
--- a/lein-template/resources/leiningen/new/duct/base/config.edn
+++ b/lein-template/resources/leiningen/new/duct/base/config.edn
@@ -3,21 +3,20 @@
  {:duct.core/project-ns <<namespace>><<#ataraxy?>>
 
   :duct.router/ataraxy
-  {:routes {<<#example?>>[:get "/example"] [:<<namespace>>.handler/example]<</example?>>}}<</ataraxy?>><<#web?>><<^ataraxy?>>
+  {:routes {<<#example?>>[:get "/example"] [:<<namespace>>.handler/example]<</example?>>}}<</ataraxy?>><<#web?>><<^ataraxy?>><<#cascading-routes>>
 
-  :duct.router/cascading
-  [<<#example?>>#ig/ref :<<namespace>>.handler/example<</example?>>]<</ataraxy?>><</web?>><<#example?>>
+  :duct.router/cascading<<&.>><</cascading-routes>><<^cascading-routes>>
 
-  :<<namespace>>.<<#web?>>handler<</web?>><<^web?>>service<</web?>>/example
-  {<<#jdbc?>>:db #ig/ref :duct.database/sql<</jdbc?>>}<</example?>>}
+  :duct.router/cascading []<</cascading-routes>><</ataraxy?>><</web?>><<#example?>>
+
+  :<<namespace>>.<<#web?>>handler<</web?>><<^web?>>service<</web?>>/example<<^jdbc?>> {}<</jdbc?>><<#jdbc?>>
+  {:db #ig/ref :duct.database/sql}<</jdbc?>><</example?>><<#profile-base>>
+  <<&.>><</profile-base>>}
 
  :duct.profile/dev   #duct/include "dev"
  :duct.profile/local #duct/include "local"
  :duct.profile/prod  {}
 
- :duct.module/logging {}<<#api?>>
- :duct.module.web/api {}<</api?>><<#site?>>
- :duct.module.web/site {}<</site?>><<#web?>><<^site?>><<^api?>>
- :duct.module/web {}<</api?>><</site?>><</web?>><<#jdbc?>>
- :duct.module/sql {}<</jdbc?>><<#cljs?>>
- :duct.module/cljs {:main <<namespace>>.client}<</cljs?>>}
+ :duct.module/logging {}<<#web?>><<^site?>><<^api?>>
+ :duct.module/web {}<</api?>><</site?>><</web?>><<#modules>>
+ <<&.>><</modules>>}

--- a/lein-template/resources/leiningen/new/duct/base/dev.edn
+++ b/lein-template/resources/leiningen/new/duct/base/dev.edn
@@ -1,3 +1,3 @@
 {{=<< >>=}}
-{<<#jdbc?>>:duct.database/sql
- {:connection-uri "<<dev-database>>"}<</jdbc?>>}
+{<<#profile-dev>><<&.>>
+ <</profile-dev>>}

--- a/lein-template/resources/leiningen/new/duct/base/project.clj
+++ b/lein-template/resources/leiningen/new/duct/base/project.clj
@@ -14,9 +14,8 @@
   :profiles
   {:dev  [:project/dev :profiles/dev]
    :repl {:prep-tasks   ^:replace ["javac" "compile"]{{#cljs?}}
-          :dependencies [[cider/piggieback "0.4.0"]]{{/cljs?}}
-          :repl-options {:init-ns user{{#cljs?}}
-                         :nrepl-middleware [cider.piggieback/wrap-cljs-repl]{{/cljs?}}}}
+          :dependencies [[cider/piggieback "0.4.0"]]{{/cljs?}}{{#repl-options}}
+          :repl-options {{&.}}{{/repl-options}}}
    :uberjar {:aot :all}
    :profiles/dev {}
    :project/dev  {:source-paths   ["dev/src"]


### PR DESCRIPTION
External profiles, to be really useful, need to be able to modify `config.edn` file (and probably some others like `dev.edn` too). This PR is an attempt to enable such a feature by adding a `:config-mods` attribute to profiles. It's a vector of functions that will be applied to the rendered `config.edn`.
We came to a conclusion that as simple solution as we do in `project.clj` (`{{#deps}}{{&.}}{{/deps}}`) is not an option here. Profiles very often not only need to add new key-value pairs to the config but also modify an existent key at deeper lvl. Perhaps we could have both: `:extra-config` and `:config-mods`...
Please check commit 166b4e4 for example usage of `:config-mods`.

I know that this PR is not fully finished (unexplained ripoffs from `leiningen.template` and lack of docstrings). But I wanted to push it through before weekend. Will continue on that on Monday.