### PR TITLE
Add Hawk dependency and auto reloading

### DIFF
--- a/lein-template/resources/leiningen/new/duct/base/project.clj
+++ b/lein-template/resources/leiningen/new/duct/base/project.clj
@@ -21,5 +21,6 @@
    :project/dev  {:source-paths   ["dev/src"]
                   :resource-paths ["dev/resources"]
                   :dependencies   [[integrant/repl "0.3.1"]
-                                   [eftest "0.5.7"]{{#dev-deps}}
+                                   [eftest "0.5.7"]
+                                   [hawk "0.2.11"]{{#dev-deps}}
                                    {{&.}}{{/dev-deps}}]}})


### PR DESCRIPTION
## Problem
There is no way to auto reload your Duct project currently. See: https://github.com/duct-framework/core/issues/12

## Solution
As stated in https://github.com/duct-framework/core/issues/12 we can add [Hawk](https://github.com/wkf/hawk) as a dependency and write our own watcher.

## Usage:
``` Clojure
lein repl
(dev)
(auto-reset)
;; From here you can change any (Clojure / EDN) file 
;; in `src/` or `resources/` and the `(reset)` command 
;; will execute in a separate thread.
```

## Notes
* The auto-reset-handler was throwing an illegal state exception because of `*ns*`
```
;; java.lang.IllegalStateException: Can't change/establish root binding of: *ns* with set
```
I _fixed_ this by binding *ns* and then changing the namespace to `dev`. However I'd gladly accept a better solution

* There's quite a lot of additions to `dev.clj`, and most of it is private. Would you like me to create a separate namespace for the auto reloading code? If so would you please provide a suggestion?