### PR TITLE
Refer auto-reset so that you can use it directly in the repl

### DIFF
--- a/lein-template/resources/leiningen/new/duct/base/dev.clj
+++ b/lein-template/resources/leiningen/new/duct/base/dev.clj
@@ -5,7 +5,7 @@
             [clojure.tools.namespace.repl :refer [refresh]]
             [clojure.java.io :as io]
             [duct.core :as duct]
-            [duct.core.repl :as duct-repl]{{#cljs?}}
+            [duct.core.repl :as duct-repl :refer [auto-reset]]{{#cljs?}}
             [duct.repl.figwheel :refer [cljs-repl]]{{/cljs?}}
             [eftest.runner :as eftest]
             [integrant.core :as ig]


### PR DESCRIPTION
Once https://github.com/duct-framework/core/pull/24 has been merged, `auto-reset` will be available for use. It would be nice to expose this to the user in development mode. This would be similar behavior to `(reset)` `(halt)` `(go)` etc.

This should be merged and tagged once https://github.com/duct-framework/core/pull/24 has been merged and tagged.