### PR TITLE
Bump duct/core version to 0.8.0

### DIFF
--- a/lein-template/resources/leiningen/new/duct/base/project.clj
+++ b/lein-template/resources/leiningen/new/duct/base/project.clj
@@ -3,7 +3,7 @@
   :url "http://example.com/FIXME"
   :min-lein-version "2.0.0"
   :dependencies [[org.clojure/clojure "1.10.0"]
-                 [duct/core "0.7.0"]{{#deps}}
+                 [duct/core "0.8.0"]{{#deps}}
                  {{&.}}{{/deps}}]
   :plugins [[duct/lein-duct "0.12.1"]]
   :main ^:skip-aot {{namespace}}.main{{#uberjar-name}}
@@ -21,5 +21,6 @@
    :project/dev  {:source-paths   ["dev/src"]
                   :resource-paths ["dev/resources"]
                   :dependencies   [[integrant/repl "0.3.1"]
+                                   [hawk "0.2.11"]
                                    [eftest "0.5.7"]{{#dev-deps}}
                                    {{&.}}{{/dev-deps}}]}})


### PR DESCRIPTION
## Problem

Currently when generating a new Duct app and bumping the version to `0.8.0` I get this error:

```
user=> (dev)
Syntax error (FileNotFoundException) compiling at (repl.clj:1:1).
Could not locate hawk/core__init.class, hawk/core.clj or hawk/core.cljc on classpath.
```

This is because `hawk` was introduced in this PR:
https://github.com/duct-framework/core/pull/24

## Correct solution?

Quoted from this source: https://github.com/technomancy/leiningen/blob/master/doc/PROFILES.md#default-profiles

> The :provided profile is used to specify dependencies that should be available
> during jar creation, but not propagated to other code that depends on your
> project. These are dependencies that the project assumes will be provided by
> whatever environment the jar is used in, but are needed during the development
> of the project. This is often used for frameworks like Hadoop that provide their
> own copies of certain libraries.

I'm not sure if this means that the end user needs to supply this dependency, but that's what I understand from this quote.

## Related Pull request: 
https://github.com/duct-framework/duct/pull/95