### PR TITLE
Add src/duct_hierarchy.edn to :resource-paths

### DIFF
--- a/lein-template/resources/leiningen/new/duct/base/project.clj
+++ b/lein-template/resources/leiningen/new/duct/base/project.clj
@@ -16,7 +16,8 @@
    :repl {:prep-tasks   ^:replace ["javac" "compile"]{{#cljs?}}
           :dependencies [[cider/piggieback "0.4.0"]]{{/cljs?}}{{#repl-options}}
           :repl-options {{&.}}{{/repl-options}}}
-   :uberjar {:aot :all}
+   :uberjar {:aot :all
+             :resource-paths ["src/duct_hierarchy.edn"]}
    :profiles/dev {}
    :project/dev  {:source-paths   ["dev/src"]
                   :resource-paths ["dev/resources"]


### PR DESCRIPTION
## Problem
When building an uberjar all `duct_hierarchy.edn` files are merged to create a full hierarchy. This works fine until you create an uberjar. Your main project's `duct_hierarchy.edn` is not included it the merged hierarchy.

## Solution
Add `src/duct_hierarchy.edn` to the uberjar's profile resource-paths. This will make sure it is included when generating the uberjar.