### PR TITLE
Profiles include files should be more specific

### DIFF
--- a/lein-template/resources/leiningen/new/duct/base/config.edn
+++ b/lein-template/resources/leiningen/new/duct/base/config.edn
@@ -13,8 +13,8 @@
   {:db #ig/ref :duct.database/sql}<</jdbc?>><</example?>><<#profile-base>>
   <<&.>><</profile-base>>}
 
- :duct.profile/dev   #duct/include "dev"
- :duct.profile/local #duct/include "local"
+ :duct.profile/dev   #duct/include "dev.edn"
+ :duct.profile/local #duct/include "local.edn"
  :duct.profile/prod  {}
 
  :duct.module/logging {}<<#web?>><<^site?>><<^api?>>


### PR DESCRIPTION
The default profile includes in the base `config.edn` file conflict with other libraries artifact names, if those artifact names have `dev` or `local` as their fist "path component".

The base `config.edn` declares two profile includes:

   :duct.profile/dev   #duct/include "dev"
   :duct.profile/local #duct/include "local"

This is a problem for artifact names that start with either `dev` or `local`.

For example, if you add the following depenency library to your (Leiningen) project:

   [dev.gethop/sql-utils "0.4.13"]

When Duct starts reading the configuration it will throw the following exception:

   Execution error at integrant.core/read-string (core.cljc:155).
   EOF while reading

The root of the problem is the line at
https://github.com/duct-framework/core/blob/28de7df11af9c95ceb157d0c5163c061a75554b3/src/duct/core.clj#L89 in the `core` library. Because if you run the following code snippet in a REPL from the a project containing the above dependency:

    user=> (dev)
    :loaded
    dev=> (io/resource "dev")
    #object[java.net.URL 0x482a879d "jar:file:/home/hop/.m2/repository/dev/gethop/sql-utils/0.4.13/sql-utils-0.4.13.jar!/dev"]
    dev=>

you can see that the return value is not the expected one from the Duct point of view (the `dev.edn` file in the project directory), but the `dev` directory from the dependency jar file.

The profile includes in the base config of the Duct template should point to the project files explicitly.

[Fixes: #112]